### PR TITLE
Fix typos and lines in tutorial text

### DIFF
--- a/src/cmd/data/tutorial_md.rs
+++ b/src/cmd/data/tutorial_md.rs
@@ -1,10 +1,11 @@
 pub static DATA: &'static str = r##"
-This is 2nd and 3rd part of the tutorial. If you would like to reset the directory at the
-intro run `rsk tutorial`
+This is 2nd and 3rd part of the tutorial. If you would like to reset the
+directory at the intro run `rsk tutorial`
 
-Note: every time `rsk tutorial ...` gets called it will delete the files it created. This
-is so that it can update the files to be interactive. If you are taking notes or creating
-other artifacts, you should do so in separate files than the ones created.
+Note: every time `rsk tutorial ...` gets called it will delete the files it
+created. This is so that it can update the files to be interactive. If you are
+taking notes or creating other artifacts, you should do so in separate files
+than the ones created.
 
 ##################################################
 # Tutorial Stage 2: high-level requirements and design specifications
@@ -13,40 +14,44 @@ other artifacts, you should do so in separate files than the ones created.
 A few changes have been made to your local directory:
  - `tutorial.rsk` has been removed
  - the `flash_card_challenge.htm` file has been added
- - the `reqs/` folder has been added with `purpose.rsk` and `high_level.rsk` in it
+ - the `reqs/` folder has been added with `purpose.rsk` and `high_level.rsk` in 
+   it
  - `.rsk/settings.rsk` has been updated with a new `artifact_paths`
 
-open `flash_card_challenge.htm` in a browser and skim through the project 
+Open `flash_card_challenge.htm` in a browser and skim through the project 
 that we will be executing. Don't worry! You don't need to know python to 
 follow along with this tutorial.
 
 Now open `reqs/purpose.rsk`. This is a rough attempt to translate the ideas
 in `flash_card_challenge.htm` into purpose statements.
 
-Purpose statements are important because they document why your project even exists -- 
-something that is important to know as you develop it! Without high-level requirements, 
-it is easy to loose sight of what your project is trying to accomplish and can be difficult 
-to keep track of which features are useful and which are not.
+Purpose statements are important because they document why your project even 
+exists -- something that is important to know as you develop it! Without
+high-level requirements, it is easy to loose sight of what your project is
+trying to accomplish and can be difficult to keep track of which features are
+useful and which are not.
 
-In addition, purpose statements allow you to specify what your project will accomplish,
-but then complete in in pieces. **rsk** will help you track which part is complete!
+In addition, purpose statements allow you to specify what your project will
+accomplish, but then complete in pieces. **rsk** will help you track which part
+is complete!
 
 > ## Exercise 1:
-> Review `reqs/purpose.rsk` and make sure it makes sense. Think about things you think should
-> be added to the purpose documentation and make notes or add artifacts in a separate file.
-> You can always return it to it's original state with `rsk tutorial 2`
+> Review `reqs/purpose.rsk` and make sure it makes sense. Think about things you
+> think should be added to the purpose documentation and make notes or add
+> artifacts in a separate file. You can always return it to it's original state 
+> with `rsk tutorial 2`
 
 Now open `high_level.rsk` in the same directory. This is mostly the high-level 
 specifications and requirements of the command/program itself.
 
 High-level specifications allows you to lay out your ideas for how a project
-should be structued before you actually write any code. It also allows you to write out
-"TODOs" that you think **should** be done, but you maybe won't get done in your
-first iteration.
+should be structued before you actually write any code. It also allows you to
+write out "TODOs" that you think **should** be done, but you maybe won't get
+done in your first iteration.
 
 > ## Exercise 2:
-> Revew the `reqs/high_level.rsk` document. Which items do you think should be done 
-> immediately, and which will have to wait? 
+> Review the `reqs/high_level.rsk` document. Which items do you think should be
+> done immediately, and which will have to wait?
 
 Now run:
 ```
@@ -62,14 +67,15 @@ Now run:
     rsk ls REQ-cmd -l
 ```
 
-This calls to list only one artifact (REQ-cmd), and displays it in the "long" format (`-l`)
+This calls to list only one artifact (REQ-cmd), and displays it in the "long"
+format (`-l`)
 
-try `rsk ls cmd -p` to search for all items with "cmd" in the name. In this case
+Try `rsk ls cmd -p` to search for all items with "cmd" in the name. In this case
 there is only one.
 
 > ## Exercise 3:
 > Play around with the `rsk ls` command a little more to get used to it, we will
-> be using it alot. Get help with:
+> be using it a lot. Get help with:
 >     `rsk ls -h`
 
 Once you are done, continue onto stage 3.
@@ -115,10 +121,10 @@ A few changes have been made to your local directory:
 > Note: for python, a directory with an `__init__.py` file is called a "module"
 > and is python's packaging mechanism.
 
-Take a look at `flash/load.py`. This contains the machinery for loading our file.
-Notice the various `#SPC` tags located in the documentation strings. This is how
-rsk knows which artifacts are implemented and where. If an artifact is implemented
-in code in this way it is marked as 100% "completed".
+Take a look at `flash/load.py`. This contains the machinery for loading our
+file. Notice the various `#SPC` tags located in the documentation strings. This
+is how rsk knows which artifacts are implemented and where. If an artifact is
+implemented in code in this way it is marked as 100% "completed".
 
 > Note: only `SPC` and `TST` artifacts can be completed in this way.
 
@@ -133,38 +139,41 @@ Run the command
 
     rsk ls SPC-load-format
 
-Notice that it is now "implemented-at" `flash/load.py`. Go to where it says it is
-implemented and confirm that the information is correct.
+Notice that it is now "implemented-at" `flash/load.py`. Go to where it says it
+is implemented and confirm that the information is correct.
 
-Head to `flash/tests/test_load.py` and notice that similar tags an be found there
-for TST artifacts.
+Head to `flash/tests/test_load.py` and notice that similar tags can be found
+there for TST artifacts.
 
 ## Exercises
- 1. run `rsk ls ARTIFACT` on an artifact that is tagged in source. Now change the tag
-      so that it is mispelled and run it again. Did the completeness change?
- 2. do the same thing for an arifact in the `partof` field for a file in `reqs/`.
-      Notice that invalid names blink red on your terminal and you get WARN messages.
-      You can use this feature to help you ensure your artifact links are correct.
+ 1. run `rsk ls ARTIFACT` on an artifact that is tagged in source. Now change
+    the tag so that it is mispelled and run it again. Did the completeness
+    change?
+ 2. do the same thing for an arifact in the `partof` field for a file in
+   `reqs/`. Notice that invalid names blink red on your terminal and you get
+    WARN messages. You can use this feature to help you ensure your artifact
+    links are correct.
 
 ##################################################
 # Documenting your own project
 
 To start documenting your own project, run `rsk init` in your project and edit
-`.rsk/settings.rsk` with the paths to find your code-implementations and documents.
-I have a few parting words of advice for using the tool:
+`.rsk/settings.rsk` with the paths to find your code-implementations and
+documents. I have a few parting words of advice for using the tool:
 
- 1. keep your artifacts high level -- don't try to design every detail using rsk.
+ 1. keep your artifacts high level -- don't try to design every detail using
+    rsk.
        Using rsk does not mean that you don't have to leave code comments!
  2. keep names short and simple. Avoid unnecessary nesting. If you have web and
-      cmdline ui elements, consider naming them just `REQ-web` and `REQ-cmd` instead
-      of `REQ-ui-web` and `REQ-ui-cmd`. Trying to nest too deep can quickly get
-      confusing.
+      cmdline ui elements, consider naming them just `REQ-web` and `REQ-cmd`
+      instead of `REQ-ui-web` and `REQ-ui-cmd`. Trying to nest too deep can
+      quickly get confusing.
  3. use `rsk ls` liberally, and check for and fix warning messages!
- 4. don't be afraid to refactor your artifacts. It is actually easier than it might
-      sound, as **rsk** will help you find broken links and incomplete items in real
-      time. Not to mention that if you use revision control (you should), your
-      artifacts can be tracked with your project -- no more having your documents
-      and your code be wildly out of sync!
+ 4. don't be afraid to refactor your artifacts. It is actually easier than it
+      might sound, as **rsk** will help you find broken links and incomplete
+      items in real time. Not to mention that if you use revision control
+      (you should), your artifacts can be tracked with your project -- no more
+      having your documents and your code be wildly out of sync!
 
 Other than that, good luck!
 
@@ -172,8 +181,8 @@ Other than that, good luck!
 # Summary and Final Words
 
 This tutorial took you part of the way through developing a simple project using
-**rsk**. I leave it as an exercise to finish the project in whichever language you are
-most comftorable. Have some fun with the rsk tool, try to break it. If you manage
-to break it or have any suggestions, please open a ticket at:
+**rsk**. I leave it as an exercise to finish the project in whichever language
+you are most comftorable. Have some fun with the rsk tool, try to break it. If
+you manage to break it or have any suggestions, please open a ticket at:
 https://github.com/vitiral/rsk/issues
 "##;

--- a/src/cmd/data/tutorial_rsk.rs
+++ b/src/cmd/data/tutorial_rsk.rs
@@ -2,18 +2,18 @@ pub const DATA: &'static str = r##"
 # Welcome to the rsk tutorial! This file is written just like
 # .rsk files are.
 #
-# you can get to this stage in the tutorial at any time by running:
+# You can get to this stage in the tutorial at any time by running:
 #
 #     rsk tutorial
 #
-# rsk is a command line, text based tool for requriements tracking.
+# rsk is a command line, text based tool for requirements tracking.
 # It aims to be easy to use by anybody and especially productive
 # for developers
 #
 # Follow along with this file to get an idea of how you can
 # easily write and track requirements in your source code
 #
-# before we continue too far, why don't you try a command? Type
+# Before we continue too far, why don't you try a command? Type
 # the following command:
 #
 #     rsk ls REQ-learn-rsk -l
@@ -30,7 +30,7 @@ text = '''
 .rsk files like this one are written in the TOML format
 you can read more about it here: https://github.com/toml-lang/toml
 
-all rsk files must end in ".rsk"
+All rsk files must end in ".rsk"
 
 They are all flat. This means rsk does not support the "[first.second]"
 syntax. This means that the "." character is illegal in names
@@ -38,7 +38,7 @@ syntax. This means that the "." character is illegal in names
 
 [REQ-learn-rsk]
 text = '''
-artifacts are defined by specifying their name like so: "[REQ-NAME]"
+Artifacts are defined by specifying their name like so: "[REQ-NAME]"
 
 Artifacts can be a requirement (REQ), design-specification (SPC)
 risk (RSK) or test (TST)
@@ -53,12 +53,12 @@ of human-readable names. We will talk more about this later.
 [SPC-learn-spc]
 partof = "REQ-toml"
 text = '''
-Anything starting with SPC is is a design specification. Requirements (REQ)
+Anything starting with SPC is a design specification. Requirements (REQ)
 should be used for detailing "what you want your application to do" and
-design specifications (SPC) shuld be used for detailing "how your application
+design specifications (SPC) should be used for detailing "how your application
 will do it".
 
-There is also tests (TST) and risks (RSK) which we will learn about later.
+There are also tests (TST) and risks (RSK) which we will learn about later.
 '''
 
 [REQ-learn-partof]
@@ -67,9 +67,9 @@ text = "see the next artifact"
 [SPC-learn-partof]
 partof = "REQ-learn-rsk"
 text = '''
-RSK uses the names of artifacts to automatically link them and track progress.
+rsk uses the names of artifacts to automatically link them and track progress.
 This makes it easy for the user to intuitively link together requirements with
-specification and reduces boilderplate.
+specification and reduces boilerplate.
 
 REQ-learn-rsk is explicitly a "partof" this artifact because it is specified
 explicitly.
@@ -95,7 +95,7 @@ REQ <-- REQ-LEARN <-- REQ-learn-partof <-- SPC-learn-partof
 ```
 
 > Note: only parents are created automatically. Auto-creating for similar-named
->   artifacts would polute your links)
+>   artifacts would pollute your links
 >
 > Note: RSK artifacts are never automatically linked by name (only their parents
 >   are automatically created and linked)
@@ -108,9 +108,11 @@ text = "this is used in the next artifact"
 partof = "SPC-learn-[spc, example]"
 text = '''
 The partof field is a string that uses a simple grouping syntax. This example
-does as you would expect, this artifact is a partof SPC-learn-spc and SPC-learn-example
+does as you would expect, this artifact is a partof SPC-learn-spc and
+SPC-learn-example
 
-note: it is also automatically a partof SPC-learn-partof and TST-LEARN because of the name
+Note: it is also automatically a partof SPC-learn-partof and TST-LEARN because
+of the name
 '''
 
 [SPC-learn-valid]
@@ -152,7 +154,7 @@ to specify risks associated with your requirements (RSK can be partof REQ).
 
 Frequently (for larger projects especially) it is a good idea to do risk
 analysis on which areas of your application are most likely to fail and
-which would be the most catestrophic. RSK artifacts allow you to document these
+which would be the most catastrophic. RSK artifacts allow you to document these
 and design test cases based on them.
 '''
 
@@ -165,8 +167,8 @@ considered "tested".
 [SPC-learn-ls]
 text = '''
 The `ls` command is the most important component to learn in rsk, as it helps you
-manage the artifacts in your project, see how they are linked, and view how completed/tested
-they are.
+manage the artifacts in your project, see how they are linked, and view how
+completed/tested they are.
 
 Type:
     rsk ls SPC-learn-ls -l
@@ -179,21 +181,21 @@ Try:
 This searches in the "Name" field for all artifacts that have "learn"
 in their name.
 
-Let's say you wanted to find an artifact, and all you knew was that it mentioned files
-in it's text field. You could run:
+Let's say you wanted to find an artifact, and all you knew was that it mentioned
+files in it's text field. You could run:
 
     rsk ls file -p T -T
 
-This will search for the pattern "file" in the text field (`-p T`). It will also display a
-short piece of the text field (`-T`)
+This will search for the pattern "file" in the text field (`-p T`). It will also
+display a short piece of the text field (`-T`)
 
 Now let's say that You see that SPC-learn-valid is what you were looking for,
 but you want an expanded view:
 
    rsk ls SPC-learn-valid -l
 
-Now you see that SPC-learn-valid has not been tested or implemented and that it is partof
-SPC-LEARN. From there you could decide what to do.
+Now you see that SPC-learn-valid has not been tested or implemented and that it
+is partof SPC-LEARN. From there you could decide what to do.
 '''
 
 ##################################################


### PR DESCRIPTION
Fix typos and align text to be below 81 characters per line.

When I followed the tutorial, I saw some typos so here is a pull request to fix them. I also limited lines length below 81 characters so it is more comfortable to read when several windows are open on the same screen.